### PR TITLE
Don't build existing makefiles in git repos

### DIFF
--- a/nix/buildFromLockFile.nix
+++ b/nix/buildFromLockFile.nix
@@ -81,6 +81,8 @@ let
             src =
               remoteSrc;
 
+            dontBuild = true;
+
             installPhase =
               ''
               mkdir $out
@@ -132,6 +134,8 @@ let
 
             src =
               remoteSrc;
+
+            dontBuild = true;
 
             installPhase =
               "mkdir $out; cp -r * $out";


### PR DESCRIPTION
- example: https://github.com/menelaos/purescript-stringutils contains a `Makefile` and we shouldn't be building those in this project.